### PR TITLE
fix: await onVaultUpdate to prevent save interruption on popup close

### DIFF
--- a/src/popup/screens/ConnectFlowScreen.tsx
+++ b/src/popup/screens/ConnectFlowScreen.tsx
@@ -77,7 +77,7 @@ function ConnectFlowScreen({ vaultData, onVaultUpdate, onBack }: ConnectFlowScre
     try {
       const contact = await createContactKey(contactName, parsed.publicKey);
       const updatedVault = await addKeyToVault(contact, vaultData);
-      onVaultUpdate(updatedVault);
+      await onVaultUpdate(updatedVault);
       setCreatedContact(contact);
       setAliceStep('create-group');
     } catch (error: any) {
@@ -103,7 +103,7 @@ function ConnectFlowScreen({ vaultData, onVaultUpdate, onBack }: ConnectFlowScre
         primaryKey?.fingerprint
       );
       const updatedVault = await addGroupToVault(group, vaultData);
-      onVaultUpdate(updatedVault);
+      await onVaultUpdate(updatedVault);
       setCreatedGroup(group);
       setAliceStep('invite');
     } catch (error: any) {
@@ -161,7 +161,7 @@ function ConnectFlowScreen({ vaultData, onVaultUpdate, onBack }: ConnectFlowScre
     try {
       const contact = await createContactKey(contactName, parsed.publicKey);
       const updatedVault = await addKeyToVault(contact, vaultData);
-      onVaultUpdate(updatedVault);
+      await onVaultUpdate(updatedVault);
       setCreatedContact(contact);
       setBobStep('share-key');
     } catch (error: any) {

--- a/src/popup/screens/DashboardScreen.tsx
+++ b/src/popup/screens/DashboardScreen.tsx
@@ -71,7 +71,7 @@ function DashboardScreen({ vaultData, onVaultUpdate, onLock, onCompose, onDecryp
     try {
       const key = await generatePersonalKey(newKeyName);
       const updatedVault = await addKeyToVault(key, vaultData);
-      onVaultUpdate(updatedVault);
+      await onVaultUpdate(updatedVault);
       setNewKeyName('');
       setModal(null);
     } catch (error) {
@@ -107,7 +107,7 @@ function DashboardScreen({ vaultData, onVaultUpdate, onLock, onCompose, onDecryp
     try {
       const contact = await createContactKey(newKeyName, parsed.publicKey);
       const updatedVault = await addKeyToVault(contact, vaultData);
-      onVaultUpdate(updatedVault);
+      await onVaultUpdate(updatedVault);
       setNewKeyName('');
       setImportKeyString('');
       setModal(null);
@@ -129,7 +129,7 @@ function DashboardScreen({ vaultData, onVaultUpdate, onLock, onCompose, onDecryp
 
     try {
       const updatedVault = await removeKeyFromVault(keyId, vaultData);
-      onVaultUpdate(updatedVault);
+      await onVaultUpdate(updatedVault);
       setSelectedKey(null);
       setModal(null);
     } catch (error) {
@@ -173,7 +173,7 @@ function DashboardScreen({ vaultData, onVaultUpdate, onLock, onCompose, onDecryp
       console.log(`🆕 [handleCreateGroup:${createId}] Updated group IDs:`, updatedVault.groups.map(g => ({ id: g.id, name: g.name })));
       
       console.log(`🆕 [handleCreateGroup:${createId}] Calling onVaultUpdate()...`);
-      onVaultUpdate(updatedVault);
+      await onVaultUpdate(updatedVault);
       
       setNewGroupName('');
       setNewGroupEmoji('🦆');
@@ -194,7 +194,7 @@ function DashboardScreen({ vaultData, onVaultUpdate, onLock, onCompose, onDecryp
 
     try {
       const updatedVault = await removeGroupFromVault(groupId, vaultData);
-      onVaultUpdate(updatedVault);
+      await onVaultUpdate(updatedVault);
       setSelectedGroup(null);
       setModal(null);
     } catch (error) {
@@ -273,7 +273,7 @@ function DashboardScreen({ vaultData, onVaultUpdate, onLock, onCompose, onDecryp
 
       const group = await createGroupFromInvitation(payload);
       const updatedVault = await addGroupToVault(group, vaultData);
-      onVaultUpdate(updatedVault);
+      await onVaultUpdate(updatedVault);
       setImportKeyString('');
       setModal(null);
       alert(`Successfully joined "${payload.groupName}"! 🎉`);

--- a/src/popup/screens/OnboardingScreen.tsx
+++ b/src/popup/screens/OnboardingScreen.tsx
@@ -41,7 +41,7 @@ function OnboardingScreen({ vaultData, onVaultUpdate, onComplete, onImport }: On
       console.log(`🔑 [OnboardingScreen.handleGenerateIdentity:${genId}] Updated vault - keys: ${updatedVault.keys.length}, groups: ${updatedVault.groups.length}`);
       
       console.log(`🔑 [OnboardingScreen.handleGenerateIdentity:${genId}] Calling onVaultUpdate...`);
-      onVaultUpdate(updatedVault);
+      await onVaultUpdate(updatedVault);
       
       // Get the public key string for sharing
       const keyString = exportPublicKey(key);


### PR DESCRIPTION
The bug was that contacts (and potentially groups/identities) were being lost when the extension popup was closed quickly after adding them.

Root cause: onVaultUpdate() was not awaited, so the UI would show success and allow the popup to close before saveVault() completed. When the popup closes, its JS context is destroyed, potentially interrupting the save.

Fixed all occurrences in:
- DashboardScreen.tsx (6 places)
- ConnectFlowScreen.tsx (3 places)
- OnboardingScreen.tsx (1 place)

Now the UI waits for the save to complete before closing modals/showing success.